### PR TITLE
Fix missing quotes and executable for Docker Quick install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -433,11 +433,12 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-			"integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+			"version": "7.22.13",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+			"integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
 			"dependencies": {
-				"@babel/highlight": "^7.22.5"
+				"@babel/highlight": "^7.22.13",
+				"chalk": "^2.4.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -481,19 +482,19 @@
 			}
 		},
 		"node_modules/@babel/core/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"bin": {
 				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.5.tgz",
-			"integrity": "sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+			"integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
 			"dependencies": {
-				"@babel/types": "^7.22.5",
+				"@babel/types": "^7.23.0",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -532,28 +533,28 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"bin": {
 				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-			"integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-			"integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
 			"dependencies": {
-				"@babel/template": "^7.22.5",
-				"@babel/types": "^7.22.5"
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -619,9 +620,9 @@
 			}
 		},
 		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz",
-			"integrity": "sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==",
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
 			"dependencies": {
 				"@babel/types": "^7.22.5"
 			},
@@ -638,9 +639,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-			"integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -667,12 +668,12 @@
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-			"integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+			"integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.22.5",
-				"chalk": "^2.0.0",
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			},
 			"engines": {
@@ -680,9 +681,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
-			"integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+			"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -723,31 +724,31 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-			"integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
 			"dependencies": {
-				"@babel/code-frame": "^7.22.5",
-				"@babel/parser": "^7.22.5",
-				"@babel/types": "^7.22.5"
+				"@babel/code-frame": "^7.22.13",
+				"@babel/parser": "^7.22.15",
+				"@babel/types": "^7.22.15"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
-			"integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
+			"version": "7.23.2",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+			"integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
 			"dependencies": {
-				"@babel/code-frame": "^7.22.5",
-				"@babel/generator": "^7.22.5",
-				"@babel/helper-environment-visitor": "^7.22.5",
-				"@babel/helper-function-name": "^7.22.5",
+				"@babel/code-frame": "^7.22.13",
+				"@babel/generator": "^7.23.0",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-hoist-variables": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.22.5",
-				"@babel/parser": "^7.22.5",
-				"@babel/types": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.23.0",
+				"@babel/types": "^7.23.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -756,12 +757,12 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
-			"integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+			"integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.22.5",
-				"@babel/helper-validator-identifier": "^7.22.5",
+				"@babel/helper-validator-identifier": "^7.22.20",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -1158,6 +1159,14 @@
 			],
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@fastify/busboy": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
+			"integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@fontsource-variable/inter": {
@@ -2286,17 +2295,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/busboy": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-			"dependencies": {
-				"streamsearch": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=10.16.0"
 			}
 		},
 		"node_modules/camelcase": {
@@ -6325,9 +6323,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.24",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-			"integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+			"version": "8.4.31",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -7463,9 +7461,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.5.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-			"integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -7714,14 +7712,6 @@
 			"integrity": "sha512-D/p41NgXOkcj1SeGhfXOwv9z1K6EV3sjAUY5aeepVbgEHv7DpKWLTjhjScyzMWAQCAgUQys1mjH0eArm4cjRGw==",
 			"dependencies": {
 				"is-arrayish": "^0.3.2"
-			}
-		},
-		"node_modules/streamsearch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-			"engines": {
-				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/string_decoder": {
@@ -8266,11 +8256,11 @@
 			"integrity": "sha512-vxZM2yNvajRmCj/SknRYGNXk2tqiy6kRNvZjJLaleG3zJbSh/aNkOqD1/CVzypw8tyHyhpzYuwQgMMhUB4ZVNQ=="
 		},
 		"node_modules/undici": {
-			"version": "5.22.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-			"integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+			"version": "5.26.3",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.26.3.tgz",
+			"integrity": "sha512-H7n2zmKEWgOllKkIUkLvFmsJQj062lSm3uA4EYApG8gLuiOM0/go9bIoC3HVaSnfg4xunowDE2i9p8drkXuvDw==",
 			"dependencies": {
-				"busboy": "^1.6.0"
+				"@fastify/busboy": "^2.0.0"
 			},
 			"engines": {
 				"node": ">=14.0"
@@ -8890,9 +8880,9 @@
 			"integrity": "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA=="
 		},
 		"node_modules/zod": {
-			"version": "3.21.4",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-			"integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+			"version": "3.22.4",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+			"integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -239,7 +239,7 @@ const modules = await getCollection("modules");
                   },
                   {
                     title: "docker",
-                    code: "docker run -t -v pwd:pwd -w pwd \\\n    ewels/multiqc .",
+                    code: "docker run -t -v `pwd`:`pwd` -w `pwd` \\\n    ewels/multiqc multiqc .",
                   },
                 ]}
                 client:idle


### PR DESCRIPTION
In the Docker Quick Install Snippet, single quotes around `pwd` and the executable are missing:

```bash
docker run -t -v pwd:pwd -w pwd ewels/multiqc .
```

will return two errors:

>  docker: Error response from daemon: the working directory 'pwd' is invalid, it needs to be an absolute path.

>  docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: ".": executable file not found in $PATH: unknown.

The correct command would be

```bash
docker run -t -v `pwd`:`pwd` -w `pwd` ewels/multiqc multiqc .
```

In addition, `npm` warned me of one critical security issue in the dependencies, so I ran `npm audit fix`. 

_PS: I could not preview the effect of the changes, because `npm run dev` failed to run, since a `config.yaml` (probably not public and under version control) was missing. So I hope this PR triggers a preview build on Netlify ;-)_ 