### PR TITLE
Runner: temporary import hack until https://github.com/ewels/MultiQC/pull/2202 is merged and released

### DIFF
--- a/src/components/run/Runner.svelte
+++ b/src/components/run/Runner.svelte
@@ -41,8 +41,8 @@
     }
     pyodideWorker.postMessage({
       code: `
-import multiqc
-multiqc.run('/data', no_ansi=True, force=True)
+from multiqc import multiqc  # TODO: revert this back to simple "import multiqc" once https://github.com/ewels/MultiQC/pull/2202 is released
+multiqc.multiqc.run('/data', no_ansi=True, force=True)
         `,
     });
   }


### PR DESCRIPTION
Fix the bug that is happening when trying to run MultiQC via the http://multiqc.info/run runner:

```sh
Uncaught (in promise) PythonError: Traceback (most recent call last):
  File "/lib/python311.zip/_pyodide/_base.py", line 571, in eval_code_async
    await CodeRunner(
  File "/lib/python311.zip/_pyodide/_base.py", line 394, in run_async
    coroutine = eval(self.code, globals, locals)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<exec>", line 3, in <module>
AttributeError: module 'multiqc' has no attribute 'run'
```

This is happenning because `run` was removed from the namespace after Ruff linting, see https://github.com/ewels/MultiQC/pull/2202. After it is released in a new MultiQC version, we can revert this PR.