### PR TITLE
Add chromium to the Dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ name: Build website docker image
 on:
   push:
     branches: [main]
+  pull_request:
 
 jobs:
   astro_docker:
@@ -36,5 +37,5 @@ jobs:
           # platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8, linux/ppc64le, linux/s390x
           # But 32-bit binaries likely require compilation from source so stick with linux/amd64 and linux/arm64 for now
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ghcr.io/multiqc/website:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@
 #######################################################################
 
 FROM node:lts-alpine AS runtime
-RUN apk add --no-cache git
+RUN apk add --no-cache git chromium
+RUN apt install chromium-browser
 WORKDIR /app
 
 # Copy the website files into the current directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@
 
 FROM node:lts-alpine AS runtime
 RUN apk add --no-cache git chromium
-RUN apt install chromium-browser
 WORKDIR /app
 
 # Copy the website files into the current directory


### PR DESCRIPTION
To fix the "Build website docker image" CI workflow.

Though it's not triggered in the PR, so it's hard to test this change before merging (and also that's why we missed the error). Perhaps makes sense to build the image in the PR as well (without pushing)?